### PR TITLE
Fix implicit type cast warnings

### DIFF
--- a/renderer.py
+++ b/renderer.py
@@ -372,7 +372,7 @@ class Renderer:
 
     @ti.func
     def set_voxel(self, idx, mat, color):
-        self.voxel_material[idx] = mat
+        self.voxel_material[idx] = ti.cast(mat, ti.i8)
         self.voxel_color[idx] = self.to_vec3u(color)
 
     @ti.func


### PR DESCRIPTION
This PR aims at eliminating the following warning when latest Taichi (https://github.com/taichi-dev/taichi/commit/9178a5be1b4d6566cb1124776a488c2498520c64) is used:
```
[W 04/26/22 16:01:17.463 432650] [type_check.cpp:visit@195] [$1094] Global store may lose precision: i8 <- i32
On line 375 of file "/home/xuyi15/taichi-voxel-challenge/renderer.py", in set_voxel:
        self.voxel_material[idx] = mat
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```