### PR TITLE
Save screenshot to `screenshot/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ outputs
 imgui.ini
 .*.swp
 .idea
+screenshot/

--- a/scene.py
+++ b/scene.py
@@ -125,6 +125,8 @@ class Scene:
                                  exposure=exposure)
 
         self.renderer.set_camera_pos(*self.camera.position)
+        if not os.path.exists('screenshot'):
+            os.makedirs('screenshot')
 
     @staticmethod
     @ti.func

--- a/scene.py
+++ b/scene.py
@@ -5,6 +5,8 @@ import numpy as np
 import taichi as ti
 from renderer import Renderer
 from math_utils import np_normalize, np_rotate_matrix
+import __main__
+
 
 VOXEL_DX = 1 / 64
 SCREEN_RES = (1280, 720)
@@ -175,7 +177,8 @@ class Scene:
             if self.window.is_pressed('p'):
                 timestamp = datetime.today().strftime('%Y-%m-%d-%H%M%S')
                 dirpath = os.getcwd()
-                fname = os.path.join(dirpath, f"screenshot{timestamp}.jpg")
+                main_filename = os.path.split(__main__.__file__)[1]
+                fname = os.path.join(dirpath, 'screenshot', f"{main_filename}-{timestamp}.jpg")
                 ti.tools.image.imwrite(img, fname)
                 print(f"Screenshot has been saved to {fname}")
             canvas.set_image(img)


### PR DESCRIPTION
文档里说截图保存在 `screenshot` 文件夹下。实际上截图只是以 `screenshot` 开头，存放在当前文件夹下。

> 可以移动相机以后按 P 键来截图，截图位于 screenshots 目录下。
>
> —— [community/voxel-challenge-2022-zh_cn.md at main · taichi-dev/community](https://github.com/taichi-dev/community/blob/main/events/voxel-challenge/voxel-challenge-2022-zh_cn.md#%E5%8F%82%E8%B5%9B%E8%A7%84%E5%88%99)

pr 包含的修改：
- 让截图放在 `screenshot` 文件夹下
- 截图以主程序的文件名作为开头，便于找对应的截图
- 自动新建 `screenshot` 文件夹


