### PR TITLE
Much faster ray traversal

### DIFF
--- a/math_utils.py
+++ b/math_utils.py
@@ -8,16 +8,25 @@ inf = 1e10
 
 @ti.func
 def out_dir(n):
-    u = ti.Vector([1.0, 0.0, 0.0])
-    if ti.abs(n[1]) < 1 - 1e-3:
-        u = n.cross(ti.Vector([0.0, 1.0, 0.0])).normalized()
-    v = n.cross(u)
-    phi = 2 * math.pi * ti.random(ti.f32)
-    r = ti.random(ti.f32)
-    ay = ti.sqrt(r)
-    ax = ti.sqrt(1 - r)
-    return ax * (ti.cos(phi) * u + ti.sin(phi) * v) + ay * n
+    # Keller, 2019. Ray Tracing Gems, p240
+    u = ti.Vector([ti.random(), ti.random()])
+    a = 1.0 - 2.0 * u[0]
+    b = ti.sqrt(1.0 - a * a)
+    phi = 2.0 * np.pi * u[1]
+    return ti.Vector([n.x + b * ti.cos(phi), n.y + a, n.z + b * ti.sin(phi)])
 
+@ti.func
+def interleave_bits_z3(v : ti.u32):
+    # https://stackoverflow.com/questions/1024754/how-to-compute-a-3d-morton-number-interleave-the-bits-of-3-ints
+    x = (v | (v << 16)) & 0x030000FF
+    x = (x | (x <<  8)) & 0x0300F00F
+    x = (x | (x <<  4)) & 0x030C30C3
+    x = (x | (x <<  2)) & 0x09249249
+    return x
+
+@ti.func
+def morton(p):
+    return interleave_bits_z3(p.x) | (interleave_bits_z3(p.y) << 1) | (interleave_bits_z3(p.z) << 2)
 
 @ti.func
 def ray_aabb_intersection(box_min, box_max, o, d):

--- a/math_utils.py
+++ b/math_utils.py
@@ -8,7 +8,7 @@ inf = 1e10
 
 @ti.func
 def out_dir(n):
-    # Keller, 2019. Ray Tracing Gems, p240
+    # Shirley, et al, 2019. Sampling Transformation Zoo. Chapter 16, Ray Tracing Gems, p240
     u = ti.Vector([ti.random(), ti.random()])
     a = 1.0 - 2.0 * u[0]
     b = ti.sqrt(1.0 - a * a)
@@ -30,8 +30,6 @@ def morton(p):
 
 @ti.func
 def ray_aabb_intersection(box_min, box_max, o, d):
-    intersect = 1
-
     near_int = -inf
     far_int = inf
 
@@ -49,8 +47,7 @@ def ray_aabb_intersection(box_min, box_max, o, d):
             far_int = ti.min(new_far_int, far_int)
             near_int = ti.max(new_near_int, near_int)
 
-    if near_int > far_int:
-        intersect = 0
+    intersect = near_int <= far_int
     return intersect, near_int, far_int
 
 

--- a/renderer.py
+++ b/renderer.py
@@ -335,10 +335,10 @@ class Renderer:
                 depth += 1
                 closest, normal, c, hit_light, iters = self.next_hit(pos, d, t)
                 hit_pos = pos + closest * d
-                if depth == 1:
-                    worst_case_iters = ti.simt.subgroup.reduce_max(iters)
-                    best_case_iters = ti.simt.subgroup.reduce_min(iters)
-                    self.color_buffer[u, v] += ti.Vector([worst_case_iters / 64.0, best_case_iters / 64.0, 0.0])
+                # if depth == 1:
+                #     worst_case_iters = ti.simt.subgroup.reduce_max(iters)
+                #     best_case_iters = ti.simt.subgroup.reduce_min(iters)
+                #     self.color_buffer[u, v] += ti.Vector([worst_case_iters / 64.0, best_case_iters / 64.0, 0.0])
                 if not hit_light and normal.norm() != 0 and closest < 1e8:
                     d = out_dir(normal)
                     pos = hit_pos + 1e-4 * d

--- a/renderer.py
+++ b/renderer.py
@@ -22,7 +22,7 @@ class Renderer:
         self.color_buffer = ti.Vector.field(3, dtype=ti.f32)
         self.bbox = ti.Vector.field(3, dtype=ti.f32, shape=2)
         self.fov = ti.field(dtype=ti.f32, shape=())
-        self.voxel_data = ti.field(dtype=ti.u32)
+        self.voxel_data = ti.field(dtype=ti.i32)
 
         self.light_direction = ti.Vector.field(3, dtype=ti.f32, shape=())
         self.light_direction_noise = ti.field(dtype=ti.f32, shape=())
@@ -132,19 +132,16 @@ class Renderer:
 
     @staticmethod
     @ti.func
-    def decode_data(data : ti.u32):
+    def decode_data(data : ti.i32):
         v = ti.Vector([data & 0xFF, (data >> 8) & 0xFF, (data >> 16) & 0xFF, data >> 24])
         return v.rgb, v.a
 
     @staticmethod
     @ti.func
     def encode_data(color, material):
-        c = ti.cast(color, ti.u32)
-        m = ti.cast(material, ti.u32)
-        return ((m   & 0xFF) << 24) | \
-               ((c.b & 0xFF) << 16) | \
-               ((c.g & 0xFF) <<  8) | \
-               ((c.r & 0xFF)      )
+        c = ti.math.clamp(ti.cast(color, ti.i32), 0, 255)
+        m = ti.math.clamp(ti.cast(material, ti.i32), 0, 255)
+        return (m << 24) | (c.b << 16) | (c.g << 8) | c.r
 
     @ti.func
     def voxel_surface_color(self, pos):

--- a/renderer.py
+++ b/renderer.py
@@ -1,7 +1,4 @@
 import math
-from unittest import runner
-
-from torch import norm
 import taichi as ti
 
 from math_utils import (eps, inf, out_dir, ray_aabb_intersection)

--- a/renderer.py
+++ b/renderer.py
@@ -348,10 +348,7 @@ class Renderer:
     
     def prepare_data(self):
         shape = (self.voxel_grid_res, self.voxel_grid_res, self.voxel_grid_res)
-        # voxel_color_ndarray = ti.Vector.ndarray(4, ti.u8, shape=shape)
         self._make_texture(self.voxel_color_texture)
-        # self.voxel_color_texture.from_ndarray(voxel_color_ndarray)
-        # self.voxel_color_texture.from_field(self.voxel_color)
         self._update_lods()
 
     @ti.func

--- a/scene.py
+++ b/scene.py
@@ -158,6 +158,7 @@ class Scene:
 
     def finish(self):
         self.renderer.recompute_bbox()
+        self.renderer.update_lods()
         canvas = self.window.get_canvas()
         spp = 1
         while self.window.running:

--- a/scene.py
+++ b/scene.py
@@ -161,6 +161,8 @@ class Scene:
         self.renderer.update_lods()
         canvas = self.window.get_canvas()
         spp = 1
+        samples = 0
+        initial_t = time.time()
         while self.window.running:
             should_reset_framebuffer = False
 
@@ -174,8 +176,8 @@ class Scene:
                 self.renderer.reset_framebuffer()
 
             t = time.time()
-            for _ in range(spp):
-                self.renderer.accumulate()
+            self.renderer.accumulate(spp)
+            samples += spp
             img = self.renderer.fetch_image()
             if self.window.is_pressed('p'):
                 timestamp = datetime.today().strftime('%Y-%m-%d-%H%M%S')
@@ -191,4 +193,8 @@ class Scene:
                 spp = max(spp, 1)
             else:
                 spp += 1
+            if samples > 1024:
+                print("1024 samples took", time.time() - initial_t)
+                samples = 0
+                initial_t = time.time()
             self.window.show()

--- a/scene.py
+++ b/scene.py
@@ -158,7 +158,7 @@ class Scene:
 
     def finish(self):
         self.renderer.recompute_bbox()
-        self.renderer.update_lods()
+        self.renderer.prepare_data()
         canvas = self.window.get_canvas()
         spp = 1
         samples = 0


### PR DESCRIPTION
Here are the changes:

1. Implemented hierarchical voxel traversal (similar to the Hi-Z ray marching algorithm). The occupancy LOD tree is stored in a bit field to reduce memory bandwidth
2. Optimized the ray traversal code, reducing worst case branch divergence (a huge deal for GPUs)
3. Added ray replacement & process multiple samples within the same kernel. (i.e. if a previous ray has exited, replace it with a new sample instead of letting the thread idle)
4. Use the voxel space (-N, N) for traversal reference instead of converting from uniform space for better precision. Using a change-of-space on AABB intersection so that the min axis is always 0 (more compiler constant folding possible)